### PR TITLE
Fix typos on geomag indices and solar wind pages

### DIFF
--- a/app/pages/geomag_indices.py
+++ b/app/pages/geomag_indices.py
@@ -5,7 +5,7 @@ from app_utils import data_last_synced, init_db, get_latest_timestamp, cached_qu
 
 conn = init_db()
 
-st.title("Geomgagnetic Indices 📡")
+st.title("Geomagnetic Indices 📡")
 
 intervals = {
     "Last 24 Hours": "24 hours",

--- a/app/pages/solar_wind.py
+++ b/app/pages/solar_wind.py
@@ -135,12 +135,12 @@ def solar_wind_section():
         st.markdown(
             """
             The solar wind is a continuous stream of charged particles
-            (plasma) emmited by the Sun's atmosphere. When this stream
+            (plasma) emitted by the Sun's atmosphere. When this stream
             of particles reaches Earth, it transfers energy into the Earth's
             magnetosphere. Solar wind is made up of two components: the
             properties of the plasma (e.g. speed and density), and the
             properties of the embedded magnetic field, which is
-            called the Interplanetary Magnetic Field (IMF). Geomganetic
+            called the Interplanetary Magnetic Field (IMF). Geomagnetic
             storms are typically triggered due to high speed solar wind
             combined with a strong IMF in the southward direction
             (Z-component). Storm intensity increases as the Bz value


### PR DESCRIPTION
Fixes two pages with typos:

- `geomag_indices.py`: "Geomgagnetic" → "Geomagnetic" in page title
- `solar_wind.py`: "emmited" → "emitted" and "Geomganetic" → "Geomagnetic" in expander text

---
_Generated by [Claude Code](https://claude.ai/code/session_019SsLi9ijoQLumnT4tNv2Hm)_